### PR TITLE
Force the use of python2 in the QEMU compilation

### DIFF
--- a/Instrumentor/qemu/build_qemu_support.sh
+++ b/Instrumentor/qemu/build_qemu_support.sh
@@ -31,7 +31,7 @@ build_qemu () {
     cd qemu-2.3.0-$1-$2 || exit 1
 
     CFLAGS="-O3" ./configure --disable-system --enable-linux-user \
-      --enable-guest-base --disable-gtk --disable-sdl --disable-vnc \
+      --python=python2 --enable-guest-base --disable-gtk --disable-sdl --disable-vnc \
       --target-list="${CPU_TARGET}-linux-user" || exit 1
 
     echo "[+] Configuration complete."


### PR DESCRIPTION
This small fix will make Eclipser easier to compile in ArchLinux.